### PR TITLE
Admin view page width reduced to single screen at > 1280px

### DIFF
--- a/app/client/templates/admin/admin.html
+++ b/app/client/templates/admin/admin.html
@@ -168,6 +168,9 @@
 
   </div>
 
+  <div class="clearfix spacer">
+  </div>
+
   {{/each}}
 
 </template>

--- a/app/client/templates/admin/admin.scss
+++ b/app/client/templates/admin/admin.scss
@@ -6,7 +6,7 @@ body.admin {
   // At present, there is no responsive styling for the admin console
   // It is designed to be viewed on an HD laptop, and will cover > 100%
   // of the screen width if viewed on a smaller screen.
-  min-width: 175rem;
+  // min-width: 155rem;
 
 }
 

--- a/app/client/templates/components/app-item.js
+++ b/app/client/templates/components/app-item.js
@@ -65,7 +65,7 @@ Template.appItem.events({
 
   'click [data-link="single-app"]': function() {
 
-    FlowRouter.go('/appMarket/app/' + this.app._id);
+    FlowRouter.go('singleApp', {appId: this.app._id});
 
   }
 
@@ -166,8 +166,8 @@ Template.appItemTiny.events({
 
   'click [data-action="admin-review"]': function() {
 
-    FlowRouter.go('/admin/review/' + this.app._id);
+    FlowRouter.go('review', {appId: this.app._id});
 
   }
 
-})
+});

--- a/app/client/templates/components/menu.scss
+++ b/app/client/templates/components/menu.scss
@@ -130,6 +130,46 @@
 
 }
 
+body.admin {
+  .menu-container {
+
+    width: 8.5rem;
+
+    .menu-link {
+
+      .menu-text {
+        display: none;
+      }
+
+    }
+  }
+
+  .menu-spacer {
+
+    margin-left: 12.5rem;
+
+    @media screen and (max-width: $small-tablet) {
+
+      margin-left: 1rem;
+      margin-right: 1rem;
+
+    }
+
+  }
+
+  .pad-right {
+
+    padding-right: 4rem;
+
+    @media screen and (max-width: $small-tablet) {
+
+      padding-right: 0;
+
+    }
+
+  }
+}
+
 .menu-spacer {
 
   margin-left: $menu-width + $app-section-padding-left;


### PR DESCRIPTION
@jadeqwang @neynah
This PR collapses the side menu to show only icons in admin view and reduces whitespace to allow the app bar to take up as much room as possible.  It's live at sandstorm-app-store-test.meteor.com - could you have a look and let me know what you think?

![sandstorm app store](https://cloud.githubusercontent.com/assets/3180526/7912332/71e56e60-085e-11e5-9268-2e9eb5e0199e.png)
