### PR TITLE
app tables now reactive, plus search bar moved to the left in topbar

### DIFF
--- a/app/client/templates/components/app-item-full-width.html
+++ b/app/client/templates/components/app-item-full-width.html
@@ -1,6 +1,6 @@
 <template name="appItemFullWidth">
 
-  <div class="app-item-container full-width">
+  <div class="app-item-container full-width approved-{{app.approved}}">
 
     <div class="app-item-inner">
 

--- a/app/client/templates/components/app-item.html
+++ b/app/client/templates/components/app-item.html
@@ -1,6 +1,6 @@
 <template name="appItem">
 
-  <div class="app-item-container {{size}} {{#if installed app}}installed{{/if}}" data-link="single-app">
+  <div class="app-item-container {{size}} {{#if installed app}}installed{{/if}} approved-{{app.approved}}" data-link="single-app">
 
     <div class="app-item-inner">
 

--- a/app/client/templates/components/app-item.scss
+++ b/app/client/templates/components/app-item.scss
@@ -2,7 +2,7 @@
 
 .app-item-container {
 
-  display: inline-block;
+  display: none;
   vertical-align: top;
   text-align: left;
   width: $app-container-width;
@@ -12,6 +12,15 @@
   padding-bottom: $app-container-margin-tb;
   box-sizing: border-box;
   cursor: pointer;
+
+  // This is a semi-hack to hide apps which are unapproved in the short period
+  // between navigating back to an app market page from the admin view and
+  // the unapproved apps being flushed from the DB. At present, Meteor doesn't
+  // provide a reactive method "stopped()" equivalent to "ready()" that you
+  // can use to test for this and delay rendering, so we use CSS instead.
+  &.approved-0, &.admin, &.full-width {
+    display: inline-block;
+  }
 
   .app-item-inner {
 

--- a/app/client/templates/components/topbar.html
+++ b/app/client/templates/components/topbar.html
@@ -29,11 +29,13 @@
           </ul>
         </div>
 
-        <input class="search-box" type="text" data-field="search-term" />
-        <button class="search-button" data-action="search-apps"><i class="icon-search"></i></button>
-
       </div>
 
+    </div>
+
+    <div class="search-section">
+      <input class="search-box" type="text" data-field="search-term" />
+      <button class="search-button" data-action="search-apps"><i class="icon-search"></i></button>      
     </div>
 
   </div>

--- a/app/client/templates/components/topbar.js
+++ b/app/client/templates/components/topbar.js
@@ -35,7 +35,7 @@ Template.Topbar.onCreated(function() {
 Template.Topbar.helpers({
   genres: function() {
 
-    var genres = Genres.getAll({where: {showSummary: true}}),
+    var genres = _.where(App.populatedGenres.get(), {showSummary: true}),
         template = Template.instance();
 
     return genres.slice(0, template.genreCount.get());
@@ -44,7 +44,7 @@ Template.Topbar.helpers({
 
   extraGenres: function() {
 
-    var genres = Genres.getAll({where: {showSummary: true}}),
+    var genres = _.where(App.populatedGenres.get(), {showSummary: true}),
         template = Template.instance();
 
     return genres.slice(template.genreCount.get());

--- a/app/client/templates/components/topbar.scss
+++ b/app/client/templates/components/topbar.scss
@@ -24,10 +24,12 @@
   .genre-holder {
 
     margin-left: $menu-width + $app-section-padding-left;
+    margin-right: 32rem;
 
     @media (max-width: $small-tablet) {
 
       margin-left: $app-section-padding-left;
+      margin-right: 0;
 
     }
 
@@ -128,6 +130,22 @@
 
     }
 
+    @media (max-width: $small-tablet) {
+
+      left: initial;
+      right: 2.33rem;
+      text-align: right;
+
+    }
+
+  }
+
+  .search-section {
+
+    position: absolute;
+    right: $app-section-padding-right;
+    bottom: $topbar-padding-bottom;
+
     .search-box {
       display: inline-block;
       vertical-align: middle;
@@ -135,14 +153,15 @@
       background: none;
       font-family: $main-font;
       font-size: $topbar-item-font-size;
-      border: 1px solid $topbar-item-bg;
+      box-shadow: inset 0 0 0 1px $topbar-item-bg;
+      border: none;
       padding-left: $topbar-item-padding-lr;
       padding-right: $topbar-item-padding-lr;
       padding-top: $topbar-item-padding-tb;
       padding-bottom: $topbar-item-padding-tb;
       &:focus {
         outline: none;
-        border: 1px solid $topbar-item-active-bg;
+        box-shadow: inset 0 0 0 1px $topbar-item-active-bg;
       }
 
       @media (max-width: $medium-phone) {
@@ -173,14 +192,6 @@
         display: none;
       }
     }
-
-  @media (max-width: $small-tablet) {
-
-    left: initial;
-    right: 2.33rem;
-    text-align: right;
-
-  }
 
   }
 

--- a/app/client/templates/genres/genres.html
+++ b/app/client/templates/genres/genres.html
@@ -44,7 +44,7 @@
 
     <div class="genre-name"><a href="{{getZippedPath 'appMarketGenre' 'genre' genre}}">{{genre}} <i class="icon-chevron-right"></i></a></div>
 
-    {{> appTable}}
+    {{> appTable genre=genre reactive=true}}
 
   {{/if}}
   {{/if}}

--- a/app/client/templates/genres/genres.js
+++ b/app/client/templates/genres/genres.js
@@ -2,7 +2,7 @@ Template.Genre.helpers({
 
   genre: function() {
 
-    return FlowRouter.current().params.authorId ? 'Apps by Author' : FlowRouter.reactiveCurrent().params.genre;
+    return FlowRouter.current().params.authorId ? 'Apps By Author' : FlowRouter.reactiveCurrent().params.genre;
 
   },
 

--- a/app/lib/collections/categories.js
+++ b/app/lib/collections/categories.js
@@ -32,6 +32,12 @@ Schemas.Categories = new SimpleSchema({
     label: "A suggested genre which has been approved (0) or rejected (1)",
     index: true,
     optional: true
+  },
+  populated: {
+    type: Boolean,
+    label: "One of more apps exist in this category",
+    defaultValue: false,
+    index: true
   }
 });
 
@@ -63,6 +69,7 @@ if (Meteor.isServer) {
       return true;
     }
   });
+
 }
 
 Categories.attachSchema(Schemas.Categories);

--- a/app/lib/collections/genres.js
+++ b/app/lib/collections/genres.js
@@ -139,10 +139,10 @@ var extraGenres = [
   },
 
   {
-    name: 'Apps by Author',
+    name: 'Apps By Author',
     selector: function() {
       return {
-        author: this.authorId || FlowRouter.current().params.authorId
+        author: this.authorId || (FlowRouter.getParam && FlowRouter.getParam(authorId))
       };
     },
     priority: 0,
@@ -223,6 +223,13 @@ Genres = {
 
 };
 
+// Cache populated genres (more efficient than checking every time a user subscribes)
+if (Meteor.isServer) {
+    Meteor.setInterval(function() {
+      App.populatedGenres = Genres.getPopulated();
+    }, 10000);
+}
+
 // UTILITY FUNCTIONS
 
 function invokeGenreFunctions(extraGenre, origSelector, origOptions, context) {
@@ -241,10 +248,9 @@ function invokeGenreFunctions(extraGenre, origSelector, origOptions, context) {
 
 function getUser(userId) {
 
-  return Meteor.users.findOne(
-        userId ||
-        this.userId ||
-        (Meteor.userId && Meteor.userId())
-      );
+  userId = userId || this.userId;
+  if (Meteor.isClient) userId = userId || Meteor.userId();
+
+  return Meteor.users.findOne(userId);
 
 }

--- a/app/lib/deep-init/lib/app.js
+++ b/app/lib/deep-init/lib/app.js
@@ -1,10 +1,10 @@
 App = {
 
   versionOlder: function(version, comparator) {
-
     return version.dateTime > comparator.dateTime;
+  },
 
-  }
+  populatedGenres: new ReactiveVar([])
 
 };
 

--- a/app/lib/routes.js
+++ b/app/lib/routes.js
@@ -22,18 +22,20 @@ function redirectOnSmallDevice(route) {
 function getSandstormServer(queryParams) {
   if (queryParams.host) amplify.store('sandstormHost', queryParams.host);
 }
-// Reroute root URI to app market
-// FlowRouter.route('/', {
-//   action: function(params, queryParams) {
-//     getSandstormServer(queryParams);
-//     FlowRouter.go('appMarket');
-//   }
-// });
+
+//
+function getPopulatedGenres() {
+  Meteor.call('genres/getPopulated', function(err, res) {
+    if (err) throw new Meteor.Error(err);
+    else App.populatedGenres.set(res);
+  });
+}
 
 FlowRouter.route('/login', {
   name: 'login',
   action: function(params, queryParams) {
     getSandstormServer(queryParams);
+    getPopulatedGenres();
     FlowLayout.render('MasterLayout', {mainSection: 'Login'});
   }
 });
@@ -56,6 +58,7 @@ FlowRouter.route('/app/:appId', {
   },
   action: function(params, queryParams) {
     getSandstormServer(queryParams);
+    getPopulatedGenres();
     FlowLayout.render('MasterLayout', {mainSection: 'SingleApp'});
   }
 });
@@ -64,6 +67,7 @@ FlowRouter.route('/', {
   name: 'appMarket',
   action: function(params, queryParams) {
     getSandstormServer(queryParams);
+    getPopulatedGenres();
     FlowLayout.render('MasterLayout', {mainSection: 'Home'});
   }
 });
@@ -77,6 +81,7 @@ FlowRouter.route('/author/:authorId', {
   },
   action: function(params, queryParams) {
     getSandstormServer(queryParams);
+    getPopulatedGenres();
     FlowLayout.render('MasterLayout', {mainSection: 'Genre'});
   }
 });
@@ -89,6 +94,7 @@ FlowRouter.route('/genre/:genre', {
   },
   action: function(params, queryParams) {
     getSandstormServer(queryParams);
+    getPopulatedGenres();
     if (params.genre !== s.capitalize(params.genre))
       FlowRouter.setParams({genre: s.capitalize(params.genre)});
 
@@ -107,6 +113,7 @@ FlowRouter.route('/search', {
   },
   action: function(params, queryParams) {
     getSandstormServer(queryParams);
+    getPopulatedGenres();
     FlowLayout.render('MasterLayout', {mainSection: 'Search'});
   }
 });
@@ -119,6 +126,7 @@ FlowRouter.route('/installed', {
   },
   action: function(params, queryParams) {
     getSandstormServer(queryParams);
+    getPopulatedGenres();
     onlyLoggedIn();
     var user = Meteor.users.findOne(Meteor.userId());
     FlowRouter.current().firstVisit = (typeof(user && user.autoupdateApps) === 'undefined');
@@ -135,6 +143,7 @@ FlowRouter.route('/apps-by-me', {
   },
   action: function(params, queryParams) {
     getSandstormServer(queryParams);
+    getPopulatedGenres();
     FlowLayout.render('MasterLayout', {mainSection: 'AppsByMe'});
   }
 });
@@ -153,6 +162,7 @@ FlowRouter.route('/edit/:appId', {
   },
   action: function(params, queryParams) {
     getSandstormServer(queryParams);
+    getPopulatedGenres();
     FlowLayout.render('MasterLayout', {mainSection: 'Edit'});
   }
 });
@@ -167,6 +177,7 @@ FlowRouter.route('/upload', {
   },
   action: function(params, queryParams) {
     getSandstormServer(queryParams);
+    getPopulatedGenres();
     FlowLayout.render('MasterLayout', {mainSection: 'Upload'});
   }
 });
@@ -185,6 +196,7 @@ FlowRouter.route('/review/:appId', {
   },
   action: function(params, queryParams) {
     getSandstormServer(queryParams);
+    getPopulatedGenres();
     if (!Roles.userIsInRole(Meteor.userId(), 'admin')) FlowRouter.go('appMarket');
     redirectOnSmallDevice();
     FlowLayout.render('MasterLayout', {mainSection: 'Review'});
@@ -203,6 +215,7 @@ FlowRouter.route('/admin', {
   },
   action: function(params, queryParams) {
     getSandstormServer(queryParams);
+    getPopulatedGenres();
     if (!Roles.userIsInRole(Meteor.userId(), 'admin')) FlowRouter.go('appMarket');
     redirectOnSmallDevice();
     FlowLayout.render('MasterLayout', {mainSection: 'Admin'});

--- a/app/server/methods.js
+++ b/app/server/methods.js
@@ -362,6 +362,11 @@ Meteor.methods({
     if (app) return app.makeInstallLink();
   },
 
+  'genres/getPopulated': function() {
+    this.unblock();
+    return App.populatedGenres;
+  },
+
   'admin/submitAdminRequests': function(app) {
 
     this.unblock();

--- a/app/server/publish.js
+++ b/app/server/publish.js
@@ -30,7 +30,7 @@ Meteor.publish('suggested categories', function() {
 });
 
 Meteor.publish('apps by genre', function (name) {
-  var apps = Genres.findIn(name, {public: true, approved: 0}, {fields: appUnpublishedFields}, this);
+  var apps = Genres.findIn(name, {public: true, approved: Apps.approval.approved}, {fields: appUnpublishedFields}, this);
   return [
     apps,
     Meteor.users.find({_id: {$in: _.uniq(apps.map(function(app) {


### PR DESCRIPTION
App tables are now all reactive and subscriptions are managed at an appropriate router or template level.  

There remains a potential problem related to the fact that Meteor does not have a "stopped" method, so there is no built-in way to determine that docs related to old subscriptions have been removed from a collection.  This should only really affect the user when navigating from an admin route or possibly "Apps by Me", and has been obviated with a CSS solution (so apps from old subs are briefly rendered before being removed from the dictionary, but hidden with CSS).  A JS solution is now possible, but would require a fork of Flow Router to use the `onStop` callback to reactively record the status of all subs even after they've been stopped and no longer relate to the current route.

This PR also moves the search box in the top bar to be right-aligned.
